### PR TITLE
chore: gitignore prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ lib-cov
 logs
 node_modules
 temp
+*prettier*
 
 auto-imports.d.ts


### PR DESCRIPTION
配置 gitignore 忽视以下 prettier 配置文件
- A `.prettierrc` file written in JSON or YAML.
- A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
- A `.prettierrc.js`, `.prettierrc.cjs`, `prettier.config.js`, or `prettier.config.cjs` file that exports an object using module.exports.
- A `.prettierrc.toml` file.

以及 prettier ignore 文件: `.prettierignore`
