### PR TITLE
refactor(types): reimagine AmNode AmClass

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from './runtime'

--- a/packages/types/src/runtime/index.ts
+++ b/packages/types/src/runtime/index.ts
@@ -7,7 +7,7 @@ export interface AmNode<T extends BasicObject = {}, N extends BasicObject = {}>
    * css 的样式对象，key 需要符合 kebab-case
    * @example { width: "10px", height: "10px" }
    */
-  styleObject: Record<string, string>
+  cssObject: Record<string, string>
 
   /**
    * @description: 允许插件在其配置中添加自己想要的配置
@@ -24,8 +24,7 @@ export interface AmClass<T extends BasicObject = {}> {
   origin: string
 
   /**
-   * 伪类、媒体查询、暗色模式等
-   * @example "hover:", "xl:", "dark:"
+   * 注解，包含伪类、媒体查询、暗色模式
    */
   annotation: AmAnnotation
 
@@ -49,6 +48,8 @@ export interface AmClass<T extends BasicObject = {}> {
 export interface AmAnnotation {
   /**
    * 伪类
+   * @enum "hover" | "active" | ...
+   * @default []
    */
   pseudo: string[]
   /**
@@ -57,7 +58,9 @@ export interface AmAnnotation {
    */
   dark: boolean
   /**
-   * 媒体查询
+   * 媒体查询分割点
+   * @enum "sm" | "md" | "lg" | "xl" | "2xl"
+   * @default []
    */
   breakpoints: string[]
 }

--- a/packages/types/src/runtime/index.ts
+++ b/packages/types/src/runtime/index.ts
@@ -1,0 +1,63 @@
+export type BasicObject = Record<string | number | symbol, unknown>
+
+// 编译器
+export interface AmNode<T extends BasicObject = {}, N extends BasicObject = {}>
+  extends AmClass<T> {
+  /**
+   * css 的样式对象，key 需要符合 kebab-case
+   * @example { width: "10px", height: "10px" }
+   */
+  styleObject: Record<string, string>
+
+  /**
+   * @description: 允许插件在其配置中添加自己想要的配置
+   */
+  options?: N
+}
+
+// 扫描器
+export interface AmClass<T extends BasicObject = {}> {
+  /**
+   * 初始的完整的 class 字符串
+   * @example "hover:bg-red/1"
+   */
+  origin: string
+
+  /**
+   * 伪类、媒体查询、暗色模式等
+   * @example "hover:", "xl:", "dark:"
+   */
+  annotation: AmAnnotation
+
+  /**
+   * 纯净的 css 字符串
+   * @example "w-1", "w-1/4", "justify-center"
+   */
+  pure: string
+
+  /**
+   * @description: 所用插件的唯一 id
+   */
+  pid: string
+
+  /**
+   * @description: 允许插件在其配置中添加自己想要的配置
+   */
+  extension?: T
+}
+
+export interface AmAnnotation {
+  /**
+   * 伪类
+   */
+  pseudo: string[]
+  /**
+   * 暗色模式
+   * @default false
+   */
+  dark: boolean
+  /**
+   * 媒体查询
+   */
+  breakpoints: string[]
+}


### PR DESCRIPTION
重新构想 AmNode 、AmClass 类型。

@amcss/transformer 将基于 AmNode ，按以下方式实现 TransformerResult

```ts
type TransformerResult = Omit<AmNode, "options" | "extension" | "pid">
```

其计算值为

```ts
type TransformerResult = {
    cssObject: Record<string, string>;
    origin: string;
    annotation: AmAnnotation;
    pure: string;
}
```

请秉持多删少补的理念 ，review PR 中字段的说明、默认值、类型等，并就 TransformerResult 的预实现，畅所欲言捏 :P 。