### PR TITLE
test(default-scanner): move special judgment to spyon in test

### DIFF
--- a/packages/default-plugin/src/DefaultPlugin.ts
+++ b/packages/default-plugin/src/DefaultPlugin.ts
@@ -59,15 +59,7 @@ export class DefaultPlugin {
     const { shortcuts } = this
     const shortcut = shortcuts[content]
 
-    let resolveTransformed = transformer(content)
-    // todo 得删除
-    if (
-      resolveTransformed
-      && (resolveTransformed.origin === 'tick-heart'
-        || resolveTransformed.origin === 'hbs'
-        || resolveTransformed.origin === 'zx')
-    )
-      resolveTransformed = null
+    const resolveTransformed = transformer(content)
 
     if (resolveTransformed)
       this._identifiedProcessing(content, resolveTransformed)

--- a/packages/default-plugin/test/default-scanner.test.ts
+++ b/packages/default-plugin/test/default-scanner.test.ts
@@ -1,5 +1,6 @@
-import * as transformer from '../../transformer/src/transformer'
+import * as transformer from '@amcss/transformer'
 import { createDefaultPlugin } from '../src/DefaultPlugin'
+// TODO: remove spyon when transfromer is right
 const rawTransformer = transformer.transformer
 const transformSpy = vi
   .spyOn(transformer, 'transformer')
@@ -9,38 +10,6 @@ const transformSpy = vi
     return rawTransformer(origin)
   })
 describe('default-scanner', () => {
-  it('should create AmClass', () => {
-    // const v1 = 'w-100'
-    // const v2 = 'hover:active:bg-black/1'
-    // expect(createAmClass(v1)).toMatchInlineSnapshot(`
-    //   {
-    //     "annotation": {
-    //       "breakpoints": [],
-    //       "dark": false,
-    //       "pseudo": [],
-    //     },
-    //     "origin": "w-100",
-    //     "pid": "Default",
-    //     "pure": "w-100",
-    //   }
-    // `)
-    // expect(createAmClass(v2)).toMatchInlineSnapshot(`
-    //   {
-    //     "annotation": {
-    //       "breakpoints": [],
-    //       "dark": false,
-    //       "pseudo": [
-    //         "hover",
-    //         "active",
-    //       ],
-    //     },
-    //     "origin": "hover:active:bg-black/1",
-    //     "pid": "Default",
-    //     "pure": "bg-black/1",
-    //   }
-    // `)
-  })
-
   it('should create AmClass from common class', () => {
     const code = '<div class="w-100">'
     const defaultPlugin = createDefaultPlugin()


### PR DESCRIPTION
- 修复 default-scanner 测试中对 transformer 的错误 import
- 移除 DefaultPlugin 中为使测试通过，添加的特殊判断，保持 DefaultPlugin 的整洁
- 后续当 transformer 完成后，即可移除掉测试中的 spyon 逻辑